### PR TITLE
esbuild 0.25.4

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -12,16 +12,20 @@ fi
 
 echo "Building for target_platform: $target_platform with GOARCH: $GOARCH"
 
+# Make sure Go module cache is writeable before and after build
 export GOPATH=${SRC_DIR}/gopath
 mkdir -p ${GOPATH}
 export GO111MODULE=auto
 export CGO_ENABLED=0
 
+# Build esbuild
 make esbuild
 
-find ${GOPATH} -type d -exec chmod u+w {} \;
-find ${GOPATH} -type f -exec chmod u+w {} \;
-
+# Install the binary
 mkdir -p $PREFIX/bin
 cp esbuild $PREFIX/bin/esbuild
+
+# Enable removal of build tree on osx
+find ${GOPATH} -type d -exec chmod u+w {} \;
+find ${GOPATH} -type f -exec chmod u+w {} \;
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -12,11 +12,9 @@ fi
 
 echo "Building for target_platform: $target_platform with GOARCH: $GOARCH"
 
-# Make sure Go module cache is writeable before and after build
+# Set up Go path
 export GOPATH=${SRC_DIR}/gopath
 mkdir -p ${GOPATH}
-export GO111MODULE=auto
-export CGO_ENABLED=0
 
 # Build esbuild
 make esbuild

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,6 +1,16 @@
+#!/bin/bash
 set -ex
 
-export GOARCH=amd64
+# Set architecture based on the target platform
+if [[ "$target_platform" == *"aarch64"* || "$target_platform" == *"arm64"* ]]; then
+    # ARM64 architecture (linux-aarch64, osx-arm64)
+    export GOARCH=arm64
+else
+    # AMD64 architecture (linux-64, osx-64, win-64)
+    export GOARCH=amd64
+fi
+
+echo "Building for target_platform: $target_platform with GOARCH: $GOARCH"
 
 export GOPATH=${SRC_DIR}/gopath
 mkdir -p ${GOPATH}

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,4 +1,17 @@
-make esbuild 
-mkdir -p $PREFIX/bin 
+set -ex
+
+export GOARCH=amd64
+
+export GOPATH=${SRC_DIR}/gopath
+mkdir -p ${GOPATH}
+export GO111MODULE=auto
+export CGO_ENABLED=0
+
+make esbuild
+
+find ${GOPATH} -type d -exec chmod u+w {} \;
+find ${GOPATH} -type f -exec chmod u+w {} \;
+
+mkdir -p $PREFIX/bin
 cp esbuild $PREFIX/bin/esbuild
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,11 +1,12 @@
+{% set name = "esbuild" %}
 {% set version = "0.25.4" %}
 
 package:
-  name: esbuild
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://github.com/evanw/esbuild/archive/refs/tags/v{{ version }}.tar.gz
+  url: https://github.com/evanw/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
   sha256: 4661a2b1d2b1db035a19eca5e771a40b6c16b23279aae02022def9fa45ed5ad9
 
 build:
@@ -22,15 +23,22 @@ requirements:
     - nodejs >=14
 
 test:
+  requires:
+    - nodejs
   commands:
     - esbuild --version
+    - esbuild --help
 
 about:
-  home: https://esbuild.github.io/
+  home: https://github.com/evanw/esbuild
   license: MIT
   license_family: MIT
   license_file: LICENSE.md
   summary: An extremely fast javascript bundler
+  description: |
+    esbuild is an extremely fast JavaScript bundler that packages up JavaScript
+    and TypeScript code for distribution on the web. Key features include:
+  doc_url: https://esbuild.github.io/
   dev_url: https://github.com/evanw/esbuild
 
 extra:


### PR DESCRIPTION
## ☆ esbuild 0.25.4 ☆
[Jira Ticket](https://anaconda.atlassian.net/browse/PKG-8230) 
[Upstream](https://github.com/evanw/esbuild)

### Changes
* Updated version number and sha256
* Fixed cross-platform builds for ARM64/AMD64 architectures
* Added proper Go module permissions to fix OSX build issues
* Updated the description and documentation links
* Improved build.sh to handle architecture detection
* Refined test section with appropriate basic tests
* Removed redundant environment variables from build script
* Moved permission fix to end of build process